### PR TITLE
StorageSharedKeyCredential  are required when creating serviceClient

### DIFF
--- a/ImageResizeWebApp/ImageResizeWebApp/Helpers/StorageHelper.cs
+++ b/ImageResizeWebApp/ImageResizeWebApp/Helpers/StorageHelper.cs
@@ -55,11 +55,16 @@ namespace ImageResizeWebApp.Helpers
         {
             List<string> thumbnailUrls = new List<string>();
 
+            // Create StorageSharedKeyCredentials object by reading
+            // the values from the configuration (appsettings.json)
+            StorageSharedKeyCredential storageCredential =
+                new StorageSharedKeyCredential(_storageConfig.AccountName, _storageConfig.AccountKey);
+
             // Create a URI to the storage account
             Uri accountUri = new Uri("https://" + _storageConfig.AccountName + ".blob.core.windows.net/");
             Console.WriteLine(" Create BlobServiceClient from the account URI " + accountUri.ToString());
             // Create BlobServiceClient from the account URI
-            BlobServiceClient blobServiceClient = new BlobServiceClient(accountUri);
+            BlobServiceClient blobServiceClient = new BlobServiceClient(accountUri, storageCredential);
             Console.WriteLine("Get reference to the container" + _storageConfig.ThumbnailContainer);
             // Get reference to the container
             BlobContainerClient container = blobServiceClient.GetBlobContainerClient(_storageConfig.ThumbnailContainer);
@@ -81,11 +86,7 @@ namespace ImageResizeWebApp.Helpers
 
                 sas.SetPermissions(BlobContainerSasPermissions.All);
 
-                // Create StorageSharedKeyCredentials object by reading
-                // the values from the configuration (appsettings.json)
-                StorageSharedKeyCredential storageCredential =
-                    new StorageSharedKeyCredential(_storageConfig.AccountName, _storageConfig.AccountKey);
-
+                
                 // Create a SAS URI to the storage account
                 UriBuilder sasUri = new UriBuilder(accountUri);
                 sasUri.Query = sas.ToSasQueryParameters(storageCredential).ToString();

--- a/ImageResizeWebApp/ImageResizeWebApp/Helpers/StorageHelper.cs
+++ b/ImageResizeWebApp/ImageResizeWebApp/Helpers/StorageHelper.cs
@@ -57,15 +57,16 @@ namespace ImageResizeWebApp.Helpers
 
             // Create a URI to the storage account
             Uri accountUri = new Uri("https://" + _storageConfig.AccountName + ".blob.core.windows.net/");
-
+            Console.WriteLine(" Create BlobServiceClient from the account URI " + accountUri.ToString());
             // Create BlobServiceClient from the account URI
             BlobServiceClient blobServiceClient = new BlobServiceClient(accountUri);
-
+            Console.WriteLine("Get reference to the container" + _storageConfig.ThumbnailContainer);
             // Get reference to the container
             BlobContainerClient container = blobServiceClient.GetBlobContainerClient(_storageConfig.ThumbnailContainer);
-
+            
             if (container.Exists())
             {
+                Console.WriteLine("Container Exists");
                 // Set the expiration time and permissions for the container.
                 // In this case, the start time is specified as a few 
                 // minutes in the past, to mitigate clock skew.
@@ -99,6 +100,7 @@ namespace ImageResizeWebApp.Helpers
                     thumbnailUrls.Add(sasBlobUri);
                 }
             }
+            
             return await Task.FromResult(thumbnailUrls);
         }
     }

--- a/ImageResizeWebApp/ImageResizeWebApp/Helpers/StorageHelper.cs
+++ b/ImageResizeWebApp/ImageResizeWebApp/Helpers/StorageHelper.cs
@@ -88,7 +88,7 @@ namespace ImageResizeWebApp.Helpers
                 // Create a SAS URI to the storage account
                 UriBuilder sasUri = new UriBuilder(accountUri);
                 sasUri.Query = sas.ToSasQueryParameters(storageCredential).ToString();
-
+                Console.WriteLine(sasUri.ToString());
                 foreach (BlobItem blob in container.GetBlobs())
                 {
                     // Create the URI using the SAS query token.


### PR DESCRIPTION
The Referenced article https://docs.microsoft.com/en-us/azure/storage/blobs/storage-secure-access-application  highlights that the access should be Private-Access only. 

However, when the ServiceClient in the StorageHelper.GetThumbNailUrls() tries to access the ServiceClient/Container Name, the Exists() call fails with ResourceNotFound errors. 

The StorageSharedKeyCredential  are required when creating the BLOBServiceURI based ServiceClient in case the Container has Private Access Only enabled. 

Submitting the fixes for the problem experienced when enabling SASToken based authentication in the Thumbnail URLs. 

